### PR TITLE
pkgconf: require libosmocore

### DIFF
--- a/libosmoabis.pc.in
+++ b/libosmoabis.pc.in
@@ -8,4 +8,4 @@ Description: C Utility Library
 Version: @VERSION@
 Libs: -L${libdir} -losmoabis
 Cflags: -I${includedir}/
-
+Requires: libosmocore

--- a/libosmotrau.pc.in
+++ b/libosmotrau.pc.in
@@ -8,3 +8,4 @@ Description: C Utility Library
 Version: @VERSION@
 Libs: -L${libdir} -losmotrau
 Cflags: -I${includedir}/
+Requires: libosmocore


### PR DESCRIPTION
osmocom/abis/e1_input.h includes osmocom/core/linuxlist.h, therefore
the .pc file(s) need a dependency on libosmocore so that the Cflags
from libosmocore.pc make an appearance on the compiler command line
when using `pkg-config libosmoabis --cflags`.